### PR TITLE
Convert the raw_demand value to a signed 32-bit integer.

### DIFF
--- a/raven/raven.py
+++ b/raven/raven.py
@@ -145,6 +145,9 @@ class Raven(object):
 
     def instantaneous_demand_handler(self, fragment):
         raw_demand = hex_to_int(fragment.find('Demand').text)
+        #with solar the value can go negative, this raw_demand is signed int, so this is the conversion 
+        if(raw_demand & 0x80000000):
+                raw_demand = -0x100000000 + raw_demand
         multiplier = hex_to_int(fragment.find('Multiplier').text)
 
         divisor = hex_to_int(fragment.find('Divisor').text)


### PR DESCRIPTION
When using solar this value can/should go negative.